### PR TITLE
Slim down php even further

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -144,29 +144,56 @@ let
     };
   };
 
-  generic' = { version, sha256, ... }@args: let php = generic args; in php.overrideAttrs (_: {
-    passthru.buildEnv = { exts ? (_: []), extraConfig ? "" }: let
-      extraInit = writeText "custom-php.ini" ''
-        ${extraConfig}
-        ${lib.concatMapStringsSep "\n" (ext: let
-          extName = lib.removePrefix "php-" (builtins.parseDrvName ext.name).name;
-          type = "${lib.optionalString (ext.zendExtension or false) "zend_"}extension";
-        in ''
-          ${type}=${ext}/lib/php/extensions/${extName}.so
-        '') (exts (callPackage ../../../top-level/php-packages.nix { inherit php; }))}
-      '';
-    in symlinkJoin {
-      name = "php-custom-${version}";
-      nativeBuildInputs = [ makeWrapper ];
-      paths = [ php ];
-      postBuild = ''
-        wrapProgram $out/bin/php \
-          --add-flags "-c ${extraInit}"
-        wrapProgram $out/bin/php-fpm \
-          --add-flags "-c ${extraInit}"
-      '';
-    };
-  });
+  generic' = { version, sha256, ... }@args:
+    let
+      php = generic args;
+      buildEnv = { exts ? (_: []), extraConfig ? "" }:
+        let
+          getExtName = ext: lib.removePrefix "php-" (builtins.parseDrvName ext.name).name;
+          extList = exts (callPackage ../../../top-level/php-packages.nix { inherit php; });
+
+          # Generate extension load configuration snippets from
+          # exts. This is an attrset suitable for use with
+          # textClosureList, which is used to put the strings in the
+          # right order - if a plugin which is dependent on another
+          # plugin is placed before its dependency, it will fail to
+          # load.
+          extensionTexts =
+            lib.listToAttrs
+              (map (ext:
+                let
+                  extName = getExtName ext;
+                  type = "${lib.optionalString (ext.zendExtension or false) "zend_"}extension";
+                in
+                  lib.nameValuePair extName {
+                    text = "${type}=${ext}/lib/php/extensions/${extName}.so";
+                    deps = lib.optionals (ext ? internalDeps) ext.internalDeps;
+                  })
+                extList);
+
+          extNames = map getExtName extList;
+          extraInit = writeText "custom-php.ini" ''
+            ${extraConfig}
+            ${lib.concatStringsSep "\n"
+              (lib.textClosureList extensionTexts extNames)}
+          '';
+        in
+          symlinkJoin {
+            name = "php-with-extensions-${version}";
+            nativeBuildInputs = [ makeWrapper ];
+            passthru.buildEnv = buildEnv;
+            paths = [ php ];
+            postBuild = ''
+              wrapProgram $out/bin/php \
+                --add-flags "-c ${extraInit}"
+              wrapProgram $out/bin/php-fpm \
+                --add-flags "-c ${extraInit}"
+            '';
+          };
+    in
+      php.overrideAttrs (_: {
+        passthru.buildEnv = buildEnv;
+      });
 
   php72base = generic' {
     version = "7.2.28";

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -1,17 +1,14 @@
 # pcre functionality is tested in nixos/tests/php-pcre.nix
-{ callPackage, config, fetchurl, lib, makeWrapper, stdenv, symlinkJoin, writeText
-, autoconf, automake, bison, flex, libtool, pkgconfig, re2c
-, apacheHttpd, gettext, libargon2, libxml2, openssl, pcre, pcre2, readline
-, sqlite, systemd, valgrind, zlib, oniguruma }:
+{ callPackage, config, fetchurl, lib, makeWrapper, stdenv, symlinkJoin
+, writeText , autoconf, automake, bison, flex, libtool, pkgconfig, re2c
+, apacheHttpd, libargon2, libxml2, pcre, pcre2 , systemd, valgrind
+}:
 
 let
   generic =
   { version
   , sha256
   , extraPatches ? []
-
-  # Build a minimal php
-  , minimalBuild ? config.php.minimal or false
 
   # Sapi flags
   , cgiSupport ? config.php.cgi or true
@@ -42,17 +39,9 @@ let
 
     nativeBuildInputs = [ autoconf automake bison flex libtool pkgconfig re2c ];
 
-    buildInputs = [ ]
-      # Deps for some base extensions
-      ++ [ gettext ]             # Gettext extension
-      ++ [ openssl openssl.dev ] # Openssl extension
-      ++ [ pcre' ]               # PCRE extension
-      ++ [ readline ]            # Readline extension
-      ++ [ zlib ]                # Zlib extension
-      ++ [ oniguruma ]           # mbstring extension
-
-      # Deps needed when building all default extensions
-      ++ lib.optionals (!minimalBuild) [ sqlite ]
+    buildInputs =
+      # PCRE extension
+      [ pcre' ]
 
       # Enable sapis
       ++ lib.optional pearSupport [ libxml2.dev ]
@@ -66,18 +55,9 @@ let
 
     CXXFLAGS = lib.optionalString stdenv.cc.isClang "-std=c++11";
 
-    configureFlags = []
+    configureFlags =
       # Disable all extensions
-      ++ lib.optional minimalBuild [ "--disable-all" ]
-
-      # A bunch of base extensions
-      ++ [ "--with-gettext=${gettext}" ]
-      ++ [ "--with-openssl" ]
-      ++ [ "--with-readline=${readline.dev}" ]
-      ++ [ "--with-zlib=${zlib.dev}" ]
-      ++ [ "--enable-mysqlnd" ] # Required to be able to build mysqli and pdo_mysql
-      ++ [ "--enable-sockets" ]
-      ++ [ "--enable-mbstring" ]
+      [ "--disable-all" ]
 
       # PCRE
       ++ lib.optionals (lib.versionAtLeast version "7.4") [ "--with-external-pcre=${pcre'.dev}" ]
@@ -211,8 +191,9 @@ let
 
   defaultPhpExtensions = {
     exts = pp: with pp.exts; ([
-      bcmath calendar curl exif ftp gd gmp intl ldap mysqli pcntl pdo_mysql
-      pdo_odbc pdo_pgsql pgsql soap sodium zip
+      bcmath calendar curl exif ftp gd gettext gmp intl ldap mysqli
+      mysqlnd openssl pcntl pdo pdo_mysql pdo_odbc pdo_pgsql
+      pgsql readline soap sodium sqlite3 zip zlib
     ] ++ lib.optionals (!stdenv.isDarwin) [ imap ]);
   };
 in {

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -219,7 +219,7 @@ let
   defaultPhpExtensions = {
     exts = pp: with pp.exts; ([
       bcmath calendar curl exif ftp gd gettext gmp intl ldap mysqli
-      mysqlnd openssl pcntl pdo pdo_mysql pdo_odbc pdo_pgsql
+      mysqlnd opcache openssl pcntl pdo pdo_mysql pdo_odbc pdo_pgsql
       pgsql readline soap sodium sqlite3 zip zlib
     ] ++ lib.optionals (!stdenv.isDarwin) [ imap ]);
   };

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -718,7 +718,7 @@ let
       , doCheck ? true
       , ...
     }: stdenv.mkDerivation {
-      pname = "php-ext-${name}";
+      pname = "php-${name}";
 
       inherit (php) version src;
       sourceRoot = "php-${php.version}/ext/${name}";
@@ -747,7 +747,7 @@ let
       checkPhase = "echo n | make test";
       installPhase = ''
         mkdir -p $out/lib/php/extensions
-        cp modules/${name}.so $out/lib/php/extensions/ext-${name}.so
+        cp modules/${name}.so $out/lib/php/extensions/${name}.so
       '';
     };
 

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -715,6 +715,7 @@ let
       , postPhpize ? ""
       , buildInputs ? []
       , zendExtension ? false
+      , doCheck ? true
       , ...
     }: stdenv.mkDerivation {
       pname = "php-ext-${name}";
@@ -724,7 +725,8 @@ let
 
       enableParallelBuilding = true;
       nativeBuildInputs = [ php autoconf pkgconfig re2c ];
-      inherit configureFlags internalDeps buildInputs zendExtension;
+      inherit configureFlags internalDeps buildInputs
+        zendExtension doCheck;
 
       preConfigure = ''
         nullglobRestore=$(shopt -p nullglob)
@@ -742,6 +744,7 @@ let
           (dep: "mkdir -p ext; ln -s ../../${dep} ext/")
           internalDeps}
       '';
+      checkPhase = "echo n | make test";
       installPhase = ''
         mkdir -p $out/lib/php/extensions
         cp modules/${name}.so $out/lib/php/extensions/ext-${name}.so
@@ -759,7 +762,10 @@ let
       { name = "bz2"; buildInputs = [ bzip2 ]; configureFlags = [ "--with-bz2=${bzip2.dev}" ]; }
       { name = "calendar"; }
       { name = "ctype"; }
-      { name = "curl"; buildInputs = [ curl ]; configureFlags = [ "--with-curl=${curl.dev}" ]; }
+      { name = "curl";
+        buildInputs = [ curl ];
+        configureFlags = [ "--with-curl=${curl.dev}" ];
+        doCheck = false; }
       { name = "dba"; }
       { name = "dom";
         buildInputs = [ libxml2 ];
@@ -770,8 +776,9 @@ let
         buildInputs = [ enchant1 ];
         configureFlags = [ "--with-enchant=${enchant1}" ];
         # enchant1 doesn't build on darwin.
-        enable = (!stdenv.isDarwin); }
-      { name = "exif"; }
+        enable = (!stdenv.isDarwin);
+        doCheck = false; }
+      { name = "exif"; doCheck = false; }
       { name = "ffi"; buildInputs = [ libffi ]; enable = lib.versionAtLeast php.version "7.4"; }
       { name = "fileinfo"; buildInputs = [ pcre' ]; }
       { name = "filter"; buildInputs = [ pcre' ]; }
@@ -783,6 +790,7 @@ let
           "--with-external-gd=${gd.dev}"
           "--enable-gd-jis-conv"
         ];
+        doCheck = false;
         enable = lib.versionAtLeast php.version "7.4"; }
       { name = "gd";
         buildInputs = [ zlib gd libXpm ];
@@ -805,10 +813,12 @@ let
         buildInputs = [ gmp ];
         configureFlags = [ "--with-gmp=${gmp.dev}" ]; }
       { name = "hash"; enable = lib.versionOlder php.version "7.4"; }
-      { name = "iconv"; configureFlags = if stdenv.isDarwin then
+      { name = "iconv";
+        configureFlags = if stdenv.isDarwin then
                            [ "--with-iconv=${libiconv}" ]
                          else
-                           [ "--with-iconv" ]; }
+                           [ "--with-iconv" ];
+        doCheck = false; }
       { name = "imap";
         buildInputs = [ uwimap openssl pam pcre' ];
         configureFlags = [ "--with-imap=${uwimap}" "--with-imap-ssl" ];
@@ -824,12 +834,13 @@ let
           "LDAP_DIR=${openldap.dev}"
           "LDAP_INCDIR=${openldap.dev}/include"
           "LDAP_LIBDIR=${openldap.out}/lib"
-        ] ++ lib.optional stdenv.isLinux "--with-ldap-sasl=${cyrus_sasl.dev}"; }
-      { name = "mbstring"; buildInputs = [ oniguruma ]; }
-      { name = "mysqli"; configureFlags = [ "--with-mysqli=mysqlnd" "--with-mysql-sock=/run/mysqld/mysqld.sock" ]; }
+        ] ++ lib.optional stdenv.isLinux "--with-ldap-sasl=${cyrus_sasl.dev}";
+        doCheck = false; }
+      { name = "mbstring"; buildInputs = [ oniguruma ]; doCheck = false; }
       { name = "mysqli";
         internalDeps = [ "mysqlnd" ];
-        configureFlags = [ "--with-mysqli=mysqlnd" "--with-mysql-sock=/run/mysqld/mysqld.sock" ]; }
+        configureFlags = [ "--with-mysqli=mysqlnd" "--with-mysql-sock=/run/mysqld/mysqld.sock" ];
+        doCheck = false; }
       { name = "mysqlnd";
         buildInputs = [ zlib openssl ];
         postPhpize = ''
@@ -845,40 +856,48 @@ let
       { name = "opcache"; buildInputs = [ pcre' ]; zendExtension = true; }
       { name = "openssl";
         buildInputs = [ openssl ];
-        configureFlags = [ "--with-openssl" ]; }
+        configureFlags = [ "--with-openssl" ];
+        doCheck = false; }
       { name = "pcntl"; }
-      { name = "pdo"; }
+      { name = "pdo"; doCheck = false; }
       { name = "pdo_dblib";
         internalDeps = [ "pdo" ];
         configureFlags = [ "--with-pdo-dblib=${freetds}" ];
         # Doesn't seem to work on darwin.
-        enable = (!stdenv.isDarwin); }
+        enable = (!stdenv.isDarwin);
+        doCheck = false; }
       # pdo_firebird (7.4, 7.3, 7.2)
       { name = "pdo_mysql";
         internalDeps = [ "mysqlnd" "pdo" ];
-        configureFlags = [ "--with-pdo-mysql=mysqlnd" ]; }
+        configureFlags = [ "--with-pdo-mysql=mysqlnd" ];
+        doCheck = false; }
       # pdo_oci (7.4, 7.3, 7.2)
       { name = "pdo_odbc";
         internalDeps = [ "pdo" ];
-        configureFlags = [ "--with-pdo-odbc=unixODBC,${unixODBC}" ]; }
+        configureFlags = [ "--with-pdo-odbc=unixODBC,${unixODBC}" ];
+        doCheck = false; }
       { name = "pdo_pgsql";
         internalDeps = [ "pdo" ];
-        configureFlags = [ "--with-pdo-pgsql=${postgresql}" ]; }
+        configureFlags = [ "--with-pdo-pgsql=${postgresql}" ];
+        doCheck = false; }
       { name = "pdo_sqlite";
         internalDeps = [ "pdo" ];
         buildInputs = [ sqlite ];
-        configureFlags = [ "--with-pdo-sqlite=${sqlite.dev}" ]; }
+        configureFlags = [ "--with-pdo-sqlite=${sqlite.dev}" ];
+        doCheck = false; }
       { name = "pgsql";
         buildInputs = [ pcre' ];
-        configureFlags = [ "--with-pgsql=${postgresql}" ]; }
-      { name = "posix"; }
+        configureFlags = [ "--with-pgsql=${postgresql}" ];
+        doCheck = false; }
+      { name = "posix"; doCheck = false; }
       { name = "pspell"; configureFlags = [ "--with-pspell=${aspell}" ]; }
       { name = "readline";
         buildInputs = [ libedit readline ];
         configureFlags = [ "--with-readline=${readline.dev}" ];
         postPhpize = lib.optionalString (lib.versionOlder php.version "7.4") ''
           substituteInPlace configure --replace 'as_fn_error $? "Please reinstall libedit - I cannot find readline.h" "$LINENO" 5' ':' 
-        ''; }
+        '';
+        doCheck = false; }
       { name = "recode";
         configureFlags = [ "--with-recode=${recode}" ];
         # Removed in php 7.4.
@@ -894,19 +913,21 @@ let
         buildInputs = [ net-snmp openssl ];
         configureFlags = [ "--with-snmp" ];
         # net-snmp doesn't build on darwin.
-        enable = (!stdenv.isDarwin); }
+        enable = (!stdenv.isDarwin);
+        doCheck = false; }
       { name = "soap";
         buildInputs = [ libxml2 ];
         configureFlags = [ "--enable-soap" ]
           # Required to build on darwin.
-          ++ lib.optional (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ]; }
-      { name = "sockets"; }
+          ++ lib.optional (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ];
+        doCheck = false; }
+      { name = "sockets"; doCheck = false; }
       { name = "sodium"; buildInputs = [ libsodium ]; }
       { name = "sqlite3"; buildInputs = [ sqlite ]; }
       { name = "sysvmsg"; }
       { name = "sysvsem"; }
       { name = "sysvshm"; }
-      { name = "tidy"; configureFlags = [ "--with-tidy=${html-tidy}" ]; }
+      { name = "tidy"; configureFlags = [ "--with-tidy=${html-tidy}" ]; doCheck = false; }
       { name = "tokenizer"; }
       { name = "wddx";
         buildInputs = [ libxml2 ];
@@ -917,7 +938,8 @@ let
         buildInputs = [ libxml2 ];
         configureFlags = [ "--enable-xml" ]
           # Required to build on darwin.
-          ++ lib.optional (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ]; }
+          ++ lib.optional (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ];
+        doCheck = false; }
       { name = "xmlreader";
         buildInputs = [ libxml2 ];
         configureFlags = [ "--enable-xmlreader CFLAGS=-I../.." ]
@@ -935,10 +957,12 @@ let
           ++ lib.optional (lib.versionOlder php.version "7.4") [ "--with-libxml-dir=${libxml2.dev}" ]; }
       { name = "xsl"; buildInputs = [ libxslt libxml2 ]; configureFlags = [ "--with-xsl=${libxslt.dev}" ]; }
       { name = "zend_test"; }
-      { name = "zip"; buildInputs = [ libzip pcre' ];
+      { name = "zip";
+        buildInputs = [ libzip pcre' ];
         configureFlags = [ "--with-zip" ]
           ++ lib.optional (lib.versionOlder php.version "7.4") [ "--with-zlib-dir=${zlib.dev}" ]
-          ++ lib.optional (lib.versionOlder php.version "7.3") [ "--with-libzip" ]; }
+          ++ lib.optional (lib.versionOlder php.version "7.3") [ "--with-libzip" ];
+        doCheck = false; }
       { name = "zlib";
         buildInputs = [ zlib ];
         configureFlags = [ "--with-zlib" ]; }


### PR DESCRIPTION
This does six main things:

- Make the base PHP build even slimmer
- Make buildEnv recursively add itself to its output
- Make the PHP-shipped extensions able to depend on each other
- Order loading of extensions after dependence
- Enable tests for the PHP-shipped extensions
- Enables opcache by default